### PR TITLE
Refactor: Implement AI Overlay for WebGL and Remove 2D Canvas Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     *   [Type-Safe AI Flows](#type-safe-ai-flows)
     *   [Recommendation for Refactoring (Code Architecture)](#recommendation-for-refactoring-code-architecture)
 *   [Visualizer](#visualizer)
-    *   [Rendering Modes (2D Canvas & WebGL)](#rendering-modes-2d-canvas--webgl)
+    *   [WebGL Rendering Pipeline](#webgl-rendering-pipeline)
     *   [Scene Management](#scene-management)
     *   [Audio Responsiveness](#audio-responsiveness)
     *   [Webcam Integration](#webcam-integration)
@@ -59,18 +59,18 @@
 ## Introduction
 Welcome to the Dynamic Audio-Reactive Visualizer! This web-based application generates captivating, real-time visualizations that respond to audio input. It leverages Artificial Intelligence through Google's Genkit framework to dynamically create and suggest scene elements, color palettes, and atmospheric effects, offering a unique and interactive visual experience.
 
-Built with a modern tech stack including Next.js, TypeScript, and Three.js for WebGL rendering, this project aims to explore the synergy between audio, visuals, and AI.
+Built with a modern tech stack including Next.js, TypeScript, and Three.js, this project uses WebGL for all rendering, aiming to explore the synergy between audio, visuals, and AI.
 
 ## Features
 *   **Real-time Audio Visualization:** Visuals dynamically react to music and sound.
-*   **Dual Rendering Modes:** Choose between 2D Canvas for simpler graphics and WebGL (via Three.js) for immersive 3D scenes.
+*   **WebGL-Powered Rendering:** Utilizes WebGL (via Three.js) for immersive and performant 3D scenes.
 *   **AI-Powered Scene Intelligence:** Utilizes Genkit with Google AI models (Gemini 1.5 Flash) for:
     *   Generating visual assets from text prompts.
     *   Creating harmonious color palettes.
     *   Suggesting scene ambiances and elements.
     *   Proposing scenes based on audio analysis.
 *   **Webcam Integration:** Incorporate your live webcam feed into the visualizations.
-*   **AI Image Overlays:** Display AI-generated images as dynamic overlays on scenes with adjustable blend modes and opacity.
+*   **AI Image Overlays:** Display AI-generated images as dynamic overlays on WebGL scenes with adjustable blend modes and opacity.
 *   **Interactive Control Panel:** Easily adjust settings, select scenes, and interact with AI tools.
 *   **Performance Monitoring:** Includes FPS counter and options for performance adjustments.
 *   **Customizable Branding:** Option to add a branding overlay.
@@ -80,7 +80,7 @@ Built with a modern tech stack including Next.js, TypeScript, and Three.js for W
 *   **Styling:** Tailwind CSS
 *   **AI Framework:** Genkit (by Google)
 *   **AI Model:** Google Gemini 1.5 Flash (via `@genkit-ai/googleai`)
-*   **3D Graphics:** Three.js
+*   **3D Graphics:** Three.js (for WebGL rendering)
 *   **State Management:** React Context API (e.g., `SettingsProvider`, `AudioDataProvider`, `SceneProvider`)
 *   **Data Fetching/Caching:** TanStack Query (formerly React Query)
 *   **Linting/Formatting:** ESLint, Prettier (configured in `package.json`)
@@ -141,7 +141,7 @@ This server runs separately (usually on `http://localhost:4000`) and is used for
 *   `src/app/`: Main application pages (Next.js App Router).
 *   `src/components/`: Reusable React components.
     *   `control-panel/`: UI for controlling visualizations and AI tools.
-    *   `visualizer/`: Components for rendering visualizations (2D/WebGL).
+    *   `visualizer/`: Components for rendering WebGL visualizations.
     *   `ui/`: Generic UI elements (buttons, sliders, etc. - likely from a library like shadcn/ui given the file names).
 *   `src/ai/`: AI-related logic, including Genkit flows.
     *   `genkit.ts`: Genkit initialization.
@@ -177,28 +177,33 @@ The project follows a modern frontend architecture, leveraging Next.js conventio
 ## Visualizer
 The core of the application, responsible for rendering the graphics. This section describes the main components related to the visual output.
 
-### Rendering Modes (2D Canvas & WebGL)
-*   The `VisualizerView.tsx` component dynamically switches between 2D Canvas and WebGL rendering.
-*   Individual scenes specify their preferred renderer type (`rendererType: '2d' | 'webgl'`).
-*   **Three.js** is employed for WebGL rendering, allowing for sophisticated 3D graphics and effects.
+### WebGL Rendering Pipeline
+*   The `VisualizerView.tsx` component exclusively uses a **WebGL rendering pipeline via Three.js** for all visual scenes. This approach ensures high-performance graphics and enables sophisticated 3D effects.
+*   The previous dual 2D Canvas / WebGL rendering system has been deprecated to streamline development and focus on the capabilities of WebGL.
 
 ### Scene Management
 *   The `SceneProvider` (React Context) manages the collection of available visual scenes and the currently active scene.
-*   Scenes are modular, with dedicated functions for initialization (`init`, `initWebGL`), drawing (`draw`, `drawWebGL`), and cleanup (`cleanupWebGL` for WebGL contexts).
+*   All scenes are designed as WebGL scenes, with dedicated functions for initialization (`initWebGL`), drawing (`drawWebGL`), and cleanup (`cleanupWebGL`).
 *   Smooth transitions between different scenes are supported.
 
 ### Audio Responsiveness
 *   The `AudioDataProvider` (React Context) processes microphone or audio file input in real-time.
 *   It provides crucial audio data like Root Mean Square (RMS) for volume, beat detection, and frequency spectrum analysis (e.g., bass, mid, treble).
-*   Visualizations use this data to react dynamically, creating a tightly synchronized audio-visual experience.
+*   Visualizations use this data to react dynamically, creating a tightly synchronized audio-visual experience within the WebGL environment.
 
 ### Webcam Integration
 *   The `WebcamFeed.tsx` component facilitates access to the user's webcam.
-*   The live webcam feed can be incorporated as a texture, background, or interactive element within visual scenes.
+*   The live webcam feed can be incorporated as a texture, background, or interactive element within WebGL visual scenes.
 
 ### AI Overlays
-*   Supports displaying AI-generated images as overlays on top of the current visualizer scene (via `settings.aiGeneratedOverlayUri`).
-*   Users can adjust blend modes and opacity for these overlays through the control panel.
+*   Supports displaying AI-generated images as overlays on top of the current WebGL visualizer scene (via `settings.aiGeneratedOverlayUri`).
+*   Users can adjust the **opacity** and **blend mode** for these overlays through the control panel. This feature is fully functional for all WebGL scenes.
+*   **Supported WebGL Blend Modes:**
+    *   `source-over` (Normal blending)
+    *   `multiply`
+    *   `screen`
+    *   `add` (often referred to as "lighter")
+*   Other complex blend modes from the `GlobalCompositeOperation` standard (e.g., `overlay`, `darken`, `lighten`, `color-dodge`, `color-burn`, `hard-light`, `soft-light`, `difference`, `exclusion`, `hue`, `saturation`, `color`, `luminosity`) will currently default to `source-over` (normal blending) in the WebGL renderer. Full support for these modes would require custom GLSL shaders.
 
 ## Configuration
 This section details how to configure the application, including environment variables and application-specific settings accessible through the UI.
@@ -216,7 +221,7 @@ This section details how to configure the application, including environment var
 ### Application Settings
 *   Global application settings are managed via the `SettingsProvider` (React Context) and are configurable through the UI control panel.
 *   These settings encompass parameters for:
-    *   **Visuals:** Active scene, rendering mode (2D/WebGL), specific scene properties.
+    *   **Visuals:** Active scene, specific WebGL scene properties.
     *   **Audio Input:** Microphone sensitivity, beat detection thresholds, FFT smoothing.
     *   **AI Interactions:** Prompts for asset generation, selected AI overlays, blend modes, opacity.
     *   **UI/Branding:** Theme options, visibility of branding elements.
@@ -257,7 +262,7 @@ The application leverages Artificial Intelligence and Machine Learning to enhanc
 This section outlines key performance aspects of the application, potential bottlenecks, and recommendations for optimization, drawing heavily from the project evaluation.
 
 ### Runtime Efficiency
-*   **Rendering Engine:** The visualizer leverages WebGL for rendering, primarily through the **Three.js** library, which is suitable for performant 2D and 3D graphics in the browser.
+*   **Rendering Engine:** The visualizer leverages WebGL for all rendering, primarily through the **Three.js** library, which is suitable for performant 2D and 3D graphics in the browser. The previous 2D canvas rendering path has been removed to focus on WebGL capabilities.
 *   **Asynchronous AI Flows:** AI-driven functionalities (Genkit flows) are designed to be asynchronous and non-blocking, preventing them from freezing the user interface during AI model interactions.
 *   **Accessibility & Page Load:** The application incorporates accessibility features such as a "Skip to main content" link and is designed to avoid blocking JavaScript calls during initial page load, contributing to a smoother startup experience.
 
@@ -267,7 +272,7 @@ This section outlines key performance aspects of the application, potential bott
     *   **Recommendation:** It is **strongly recommended to implement cache eviction policies** (e.g., Least Recently Used - LRU) or set maximum size limits for these in-memory caches to prevent memory exhaustion.
 *   **Management of Generated Assets:**
     *   Visual assets generated for scenes (e.g., textures, 3D meshes) can also accumulate in memory.
-    *   **Recommendation:** Effective cleanup mechanisms for these assets are crucial, especially when users frequently switch between scenes or regenerate elements within a single session. This involves ensuring WebGL resources are properly disposed of when no longer needed.
+    *   **Recommendation:** Effective cleanup mechanisms for these assets are crucial, especially when users frequently switch between scenes or regenerate elements within a single session. This involves ensuring WebGL resources (textures, geometries, materials) are properly disposed of (`dispose()` method in Three.js) when no longer needed.
 
 ### Scalability
 *   **Load Testing:** The project evaluation found no evidence of formal load testing.
@@ -299,7 +304,7 @@ Many features detailed in the blueprint or identified as desirable are not yet i
 *   **Comprehensive Logging:** Advanced client-side logging (e.g., using IndexedDB for FRP logs or detailed interaction logs).
 *   **Undo/Redo Functionality:** Lack of undo/redo capabilities in the control panel for user actions.
 *   **Full Mobile Support:** While the application might be viewable on mobile, dedicated responsive design and performance optimization for mobile devices are not fully realized.
-*   **Style-Transfer Shader:** The "Style-Transfer Shader" is noted as a placeholder in `docs/blueprint.md` and awaits implementation.
+*   **Style-Transfer Shader:** The "Style-Transfer Shader" is noted as a placeholder in `docs/blueprint.md` and awaits implementation. This would likely require custom GLSL shaders.
 *   **Localization (i18n) Support:** The application currently lacks infrastructure for internationalization and localization.
 
 ### Development Tooling & Process Gaps
@@ -309,7 +314,7 @@ Many features detailed in the blueprint or identified as desirable are not yet i
 
 ### Documentation Status
 *   **Initial README:** Prior to this current documentation effort, the `README.md` was minimal.
-*   **Current README Enhancement:** This README has been significantly updated to reflect insights from the project evaluation, providing a more comprehensive overview.
+*   **Current README Enhancement:** This README has been significantly updated to reflect insights from the project evaluation and recent codebase refactoring, providing a more comprehensive overview.
 *   **Further Documentation Needs:**
     *   **Inline Code Comments:** More detailed inline comments explaining complex logic within the codebase would aid maintainability.
     *   **Blueprint Expansion:** The `docs/blueprint.md` could be further detailed or broken down into more specific design documents.
@@ -387,7 +392,7 @@ This section outlines potential risks identified during the project evaluation a
 *   **`dangerouslySetInnerHTML`:** The application uses `dangerouslySetInnerHTML` in the `<head>` for a CSS reset. The evaluation notes that this is with static content, making the direct XSS risk low in this specific instance.
 *   **Recommendations:**
     *   **Content Security Policy (CSP):** Implement a robust CSP to mitigate risks of XSS and other injection attacks.
-    *   **Input Sanitization:** While current text inputs seem primarily for Canvas/WebGL rendering (not direct HTML), any user-generated text that might be rendered directly into the UI in the future should be rigorously sanitized.
+    *   **Input Sanitization:** While current text inputs seem primarily for WebGL rendering (not direct HTML), any user-generated text that might be rendered directly into the UI in the future should be rigorously sanitized.
     *   **CodeQL Scans:** Regularly run CodeQL scans (or similar SAST tools) on the JavaScript/TypeScript codebase to automatically flag potential security issues, including any unsafe uses of `innerHTML` or vulnerabilities in third-party dependencies.
 
 ### Bias & Ethical AI Risks & Mitigations

--- a/src/components/visualizer/VisualizerView.tsx
+++ b/src/components/visualizer/VisualizerView.tsx
@@ -9,7 +9,7 @@ import { useScene } from '@/providers/SceneProvider';
 import { BrandingOverlay } from './BrandingOverlay';
 import { WebcamFeed } from './WebcamFeed';
 import * as THREE from 'three';
-import { SBNF_BODY_FONT_FAMILY, SBNF_TITLE_FONT_FAMILY } from '@/lib/brandingConstants';
+// SBNF_BODY_FONT_FAMILY and SBNF_TITLE_FONT_FAMILY likely unused now, will confirm later.
 
 /**
  * @fileOverview The main component responsible for rendering the visualizer canvas.
@@ -26,20 +26,15 @@ export function VisualizerView() {
   const [webcamElement, setWebcamElement] = useState<HTMLVideoElement | null>(null);
   const [lastError, setLastError] = useState<string | null>(null);
   const aiOverlayImageRef = useRef<HTMLImageElement | null>(null);
+  const [aiOverlayTexture, setAiOverlayTexture] = useState<THREE.CanvasTexture | null>(null);
+  const aiOverlayTextureRef = useRef<THREE.CanvasTexture | null>(null); // For cleanup
 
   // WebGL specific refs
   const webGLRendererRef = useRef<THREE.WebGLRenderer | null>(null);
   const currentSceneWebGLAssetsRef = useRef<any>(null); // Holds assets from currentScene.initWebGL
   const previousSceneWebGLAssetsRef = useRef<any>(null); // For cleaning up previous WebGL scene assets
 
-  // Scene transition refs (for 2D scenes)
-  const previousScene2DRef = useRef<SceneDefinition | null>(null);
-  const [isTransitioning2D, setIsTransitioning2D] = useState(false);
-  const transition2DStartTimeRef = useRef<number>(0);
   const lastSceneIdRef = useRef<string | undefined>(settings.currentSceneId);
-
-  // Canvas key for forcing re-mount on renderer type change
-  const [canvasKey, setCanvasKey] = useState(0);
 
   // FPS Counter states
   const lastFrameTimeRef = useRef(performance.now());
@@ -49,24 +44,7 @@ export function VisualizerView() {
   const fpsDropThreshold = 10;
   const fpsLogIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
-
-  const get2DContext = useCallback((): CanvasRenderingContext2D | null => {
-    const canvas = canvasRef.current;
-    if (!canvas) return null;
-    // Check if the canvas is already claimed by WebGL for this key
-    if (webGLRendererRef.current && webGLRendererRef.current.domElement === canvas) {
-        // console.warn("VisualizerView: Attempted to get 2D context on a canvas with active WebGL context.");
-        return null;
-    }
-    try {
-      return canvas.getContext('2d');
-    } catch (e) {
-      console.error("VisualizerView: Error getting 2D context:", e);
-      return null;
-    }
-  }, []);
-
-  // Scene initialization and cleanup effect (for both 2D and WebGL)
+  // Scene initialization and cleanup effect (now WebGL only)
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -74,118 +52,147 @@ export function VisualizerView() {
     const newSceneDefinition = scenes.find(s => s.id === settings.currentSceneId) || null;
     const prevSceneObject = scenes.find(s => s.id === lastSceneIdRef.current) || null;
 
-    // Canvas re-keying if renderer type fundamentally changes
-    const prevRendererType = prevSceneObject?.rendererType || '2d';
-    const newRendererType = newSceneDefinition?.rendererType || '2d';
+    // --- Start of Simplified WebGL Initialization Logic ---
+    // Always assume WebGL. No more renderer type checks or canvas re-keying.
 
-    if (prevRendererType !== newRendererType) {
-      console.log(`VisualizerView: Renderer type changed from ${prevRendererType} to ${newRendererType}. Remounting canvas.`);
-      
-      // Explicitly clean up previous WebGL assets if switching FROM WebGL
-      if (prevRendererType === 'webgl' && prevSceneObject?.cleanupWebGL && previousSceneWebGLAssetsRef.current) {
-        console.log(`VisualizerView: Cleaning up WebGL assets for previous scene: ${prevSceneObject.id} (due to renderer type switch)`);
-        prevSceneObject.cleanupWebGL(previousSceneWebGLAssetsRef.current);
-        previousSceneWebGLAssetsRef.current = null;
-      }
-      if (webGLRendererRef.current) {
-        console.log("VisualizerView: Disposing main WebGL renderer due to renderer type switch.");
-        webGLRendererRef.current.dispose();
-        webGLRendererRef.current = null;
-      }
-      currentSceneWebGLAssetsRef.current = null; // Clear current assets too before re-key
-      setCanvasKey(prevKey => prevKey + 1); // This will trigger re-mount and re-run of this effect
-      lastSceneIdRef.current = settings.currentSceneId;
-      return; 
+    // Clean up previous WebGL scene assets if the scene is changing 
+    // and the previous scene was a WebGL scene with a cleanup function.
+    if (prevSceneObject && prevSceneObject.id !== newSceneDefinition?.id && 
+        prevSceneObject.cleanupWebGL && previousSceneWebGLAssetsRef.current) {
+      console.log(`VisualizerView: Cleaning up WebGL assets for previous scene: ${prevSceneObject.id}`);
+      prevSceneObject.cleanupWebGL(previousSceneWebGLAssetsRef.current);
+      previousSceneWebGLAssetsRef.current = null; // Clear the ref after cleanup
     }
 
-    // Handle 2D scene transitions (only if both old and new are 2D)
-    if (newRendererType === '2d' && prevRendererType === '2d') {
-        if (settings.sceneTransitionActive && settings.sceneTransitionDuration > 0 && prevSceneObject && newSceneDefinition?.id !== prevSceneObject.id) {
-            previousScene2DRef.current = prevSceneObject;
-            setIsTransitioning2D(true);
-            transition2DStartTimeRef.current = performance.now();
-        } else {
-            previousScene2DRef.current = null;
-            setIsTransitioning2D(false);
-        }
-    } else { 
-        previousScene2DRef.current = null;
-        setIsTransitioning2D(false);
-    }
-
-    // WebGL Initialization / Cleanup Logic
-    if (newSceneDefinition?.rendererType === 'webgl' && newSceneDefinition.initWebGL) {
-      console.log(`VisualizerView: Initializing WebGL for scene: ${newSceneDefinition.id} (Canvas Key: ${canvasKey})`);
-      
-      // Clean up previous WebGL scene assets if it was different and also WebGL
-      if (previousSceneWebGLAssetsRef.current && prevSceneObject?.id !== newSceneDefinition.id && prevSceneObject?.rendererType === 'webgl' && prevSceneObject.cleanupWebGL) {
-        console.log(`VisualizerView: Cleaning up WebGL assets for previous scene: ${prevSceneObject.id}`);
-        prevSceneObject.cleanupWebGL(previousSceneWebGLAssetsRef.current);
-      }
+    if (newSceneDefinition && newSceneDefinition.initWebGL) {
+      console.log(`VisualizerView: Initializing WebGL for scene: ${newSceneDefinition.id}`);
       
       if (!webGLRendererRef.current) {
-        console.log("VisualizerView: Creating new WebGLRenderer instance for canvas key:", canvasKey);
-        webGLRendererRef.current = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+        console.log("VisualizerView: Creating new WebGLRenderer instance.");
+        try {
+          webGLRendererRef.current = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+          webGLRendererRef.current.setPixelRatio(window.devicePixelRatio); // Set pixel ratio once
+        } catch (e) {
+            console.error("VisualizerView: Failed to create WebGLRenderer:", e);
+            setLastError(e instanceof Error ? e.message : String(e));
+            currentSceneWebGLAssetsRef.current = null; // Ensure assets are cleared
+            previousSceneWebGLAssetsRef.current = null;
+            lastSceneIdRef.current = settings.currentSceneId;
+            return; // Stop if renderer creation fails
+        }
       }
+      
       // Always ensure renderer is configured for the current canvas dimensions
-      webGLRendererRef.current.setSize(canvas.width, canvas.height);
-      webGLRendererRef.current.setPixelRatio(window.devicePixelRatio);
+      // This should ideally be handled by the resize observer, but good to have here too.
+      if (webGLRendererRef.current.domElement.width !== canvas.width || webGLRendererRef.current.domElement.height !== canvas.height) {
+        webGLRendererRef.current.setSize(canvas.width, canvas.height);
+      }
 
       try {
+        // Initialize the new scene's assets
         const initializedAssets = newSceneDefinition.initWebGL(canvas, settings, webcamElement);
         currentSceneWebGLAssetsRef.current = initializedAssets;
-        previousSceneWebGLAssetsRef.current = initializedAssets; 
-        setLastError(null);
+        previousSceneWebGLAssetsRef.current = initializedAssets; // Keep track for next cleanup
+        if (lastError) setLastError(null); // Clear any previous init error
       } catch (e) {
         console.error("VisualizerView: Error during WebGL initialization for scene:", newSceneDefinition.id, e);
         setLastError(e instanceof Error ? e.message : String(e));
-        if (webGLRendererRef.current) { webGLRendererRef.current.dispose(); webGLRendererRef.current = null; }
+        // Don't dispose the main renderer here, just clear assets. 
+        // An error in one scene's init shouldn't kill the main renderer.
         currentSceneWebGLAssetsRef.current = null;
-        previousSceneWebGLAssetsRef.current = null;
+        previousSceneWebGLAssetsRef.current = null; // No assets to clean for this failed scene
       }
-    } else { 
-      // New scene is 2D or null, or no initWebGL function
-      // Clean up previous WebGL scene assets if switching FROM WebGL to 2D
-      if (prevRendererType === 'webgl' && prevSceneObject?.cleanupWebGL && previousSceneWebGLAssetsRef.current) {
-         console.log(`VisualizerView: Cleaning up WebGL assets for previous scene: ${prevSceneObject.id} (switching to 2D/none)`);
-        prevSceneObject.cleanupWebGL(previousSceneWebGLAssetsRef.current);
-        previousSceneWebGLAssetsRef.current = null;
+    } else {
+      // No new scene definition or it's not a WebGL scene (which shouldn't happen anymore)
+      // or it's missing initWebGL.
+      // If there was a previous scene, its assets should have been cleaned above.
+      // If no new scene, clear current assets.
+      currentSceneWebGLAssetsRef.current = null; 
+      if (newSceneDefinition) {
+        console.warn(`VisualizerView: Scene ${newSceneDefinition.id} is missing initWebGL or is not a WebGL scene.`);
+      } else if (settings.currentSceneId) {
+        console.warn(`VisualizerView: Scene with ID ${settings.currentSceneId} not found.`);
       }
-      // Dispose of the shared WebGL renderer if no WebGL scene is active
-      if (webGLRendererRef.current) {
-        console.log("VisualizerView: Current scene is not WebGL. Disposing existing WebGL renderer for canvas key:", canvasKey);
-        webGLRendererRef.current.dispose();
-        webGLRendererRef.current = null;
-      }
-      currentSceneWebGLAssetsRef.current = null;
     }
+    // --- End of Simplified WebGL Initialization Logic ---
     
     lastSceneIdRef.current = settings.currentSceneId;
 
+    // Cleanup function for this effect
     return () => {
-      // This cleanup now focuses on the assets of the scene *that was just active*
-      // It will run when settings.currentSceneId changes, or webcamElement changes, or the canvasKey changes (unmounting)
-      const sceneToClean = scenes.find(s => s.id === lastSceneIdRef.current); // Use the ID that *was* active
-      if (sceneToClean?.rendererType === 'webgl' && sceneToClean.cleanupWebGL && previousSceneWebGLAssetsRef.current) {
-        // Use previousSceneWebGLAssetsRef because that holds the assets of the scene we are leaving
-        console.log(`VisualizerView Effect Cleanup: Cleaning up WebGL assets for scene: ${sceneToClean.id}`);
+      // This cleanup runs if settings.currentSceneId, scenes, webcamElement, or settings change.
+      // It should clean up the assets of the scene that was active *before* the change.
+      const sceneToClean = scenes.find(s => s.id === lastSceneIdRef.current); 
+      if (sceneToClean && sceneToClean.cleanupWebGL && previousSceneWebGLAssetsRef.current) {
+        console.log(`VisualizerView Effect Cleanup: Cleaning up WebGL assets for scene: ${sceneToClean.id} due to effect re-run.`);
         sceneToClean.cleanupWebGL(previousSceneWebGLAssetsRef.current);
         previousSceneWebGLAssetsRef.current = null;
       }
     };
-  }, [settings.currentSceneId, scenes, canvasKey, webcamElement, settings]); // Added settings for initWebGL context
+  }, [settings.currentSceneId, scenes, webcamElement, settings, lastError]); // Removed canvasKey, added lastError
 
+
+  useEffect(() => {
+    // Update the ref whenever the state changes, for reliable cleanup
+    aiOverlayTextureRef.current = aiOverlayTexture;
+  }, [aiOverlayTexture]);
+
+  // Component unmount cleanup
+  useEffect(() => {
+    return () => {
+      // This executes when the component unmounts
+      if (aiOverlayTextureRef.current) {
+        console.log("VisualizerView: Disposing AI overlay texture on component unmount.");
+        aiOverlayTextureRef.current.dispose();
+        aiOverlayTextureRef.current = null; // Clear the ref
+      }
+    };
+  }, []); // Empty dependency array ensures this runs only on mount and unmount
 
   useEffect(() => {
     if (settings.enableAiOverlay && settings.aiGeneratedOverlayUri) {
       const img = new Image();
-      img.onload = () => { aiOverlayImageRef.current = img; };
-      img.onerror = () => { console.error("VisualizerView: Failed to load AI overlay image."); aiOverlayImageRef.current = null; };
+      img.crossOrigin = "anonymous"; // Recommended for images from other origins
+      img.onload = () => {
+        aiOverlayImageRef.current = img; // Keep the HTMLImageElement ref updated
+        
+        const newTexture = new THREE.CanvasTexture(img);
+        newTexture.needsUpdate = true;
+        
+        // Dispose the previous texture before setting the new one
+        setAiOverlayTexture(prevTexture => {
+          if (prevTexture && prevTexture !== newTexture) { // Avoid self-disposal if somehow same instance
+            prevTexture.dispose();
+          }
+          return newTexture;
+        });
+      };
+      img.onerror = () => {
+        console.error("VisualizerView: Failed to load AI overlay image.");
+        aiOverlayImageRef.current = null;
+        setAiOverlayTexture(prevTexture => {
+          if (prevTexture) {
+            prevTexture.dispose();
+          }
+          return null;
+        });
+      };
       img.src = settings.aiGeneratedOverlayUri;
     } else {
       aiOverlayImageRef.current = null;
+      setAiOverlayTexture(prevTexture => {
+        if (prevTexture) {
+          prevTexture.dispose();
+        }
+        return null;
+      });
     }
-  }, [settings.enableAiOverlay, settings.aiGeneratedOverlayUri]);
+    // The cleanup function for *this specific effect* is intentionally minimal here.
+    // The logic within the effect already handles disposing and nullifying the texture
+    // when settings.enableAiOverlay or settings.aiGeneratedOverlayUri change.
+    // The component-level unmount effect handles the final cleanup.
+    return () => {}; 
+  }, [settings.enableAiOverlay, settings.aiGeneratedOverlayUri, setAiOverlayTexture]); 
 
   const updateFps = useCallback(() => {
     const now = performance.now();
@@ -203,7 +210,7 @@ export function VisualizerView() {
     if (fpsLogIntervalRef.current) clearInterval(fpsLogIntervalRef.current);
     fpsLogIntervalRef.current = setInterval(() => {
       if (!settings.panicMode && fps > 0) {
-        console.log(`[Performance Monitor] Current FPS: ${fps}`);
+        // console.log(`[Performance Monitor] Current FPS: ${fps}`); // Kept for debugging if needed
         if (lastLoggedFpsRef.current > 0 && (lastLoggedFpsRef.current - fps > fpsDropThreshold)) {
            console.warn(`[Performance Monitor] Significant FPS drop detected! From ~${lastLoggedFpsRef.current} to ${fps}`);
         }
@@ -215,105 +222,7 @@ export function VisualizerView() {
     };
   }, [fps, settings.panicMode]);
 
-  const drawPrimarySceneContent = useCallback((
-    ctx: CanvasRenderingContext2D,
-    sceneToDraw: SceneDefinition,
-    alpha: number = 1
-  ) => {
-    if (sceneToDraw.draw) {
-      ctx.save();
-      ctx.globalAlpha = alpha;
-      sceneToDraw.draw(ctx, audioData, settings, webcamElement);
-      ctx.restore();
-    }
-  }, [audioData, settings, webcamElement]);
-
-  const drawAiGeneratedOverlay2D = useCallback((ctx: CanvasRenderingContext2D | null) => {
-    if (settings.enableAiOverlay && aiOverlayImageRef.current && ctx) {
-      const originalAlpha = ctx.globalAlpha;
-      const originalCompositeOperation = ctx.globalCompositeOperation;
-      ctx.globalAlpha = settings.aiOverlayOpacity;
-      ctx.globalCompositeOperation = settings.aiOverlayBlendMode;
-      ctx.drawImage(aiOverlayImageRef.current, 0, 0, ctx.canvas.width, ctx.canvas.height);
-      ctx.globalAlpha = originalAlpha;
-      ctx.globalCompositeOperation = originalCompositeOperation;
-    }
-  }, [settings.enableAiOverlay, settings.aiOverlayOpacity, settings.aiOverlayBlendMode]);
-
-  const drawDebugInfo = useCallback((ctx: CanvasRenderingContext2D | null) => {
-    if (!ctx) return;
-    const canvas = ctx.canvas;
-    ctx.font = `12px var(--font-geist-mono, monospace)`; // GeistMono is now disabled, uses fallback
-    const currentFgColor = getComputedStyle(canvas).getPropertyValue('--foreground').trim() || 'white';
-    ctx.fillStyle = currentFgColor;
-    
-    ctx.textAlign = 'left';
-    ctx.fillText(`FPS: ${fps}`, 10, 20);
-
-    const spectrumSample = Array.from(audioData.spectrum.slice(0,5));
-    const spectrumSum = audioData.spectrum.reduce((s, v) => s + v, 0);
-    // console.log(
-    //     'VisualizerView - AudioData (from VisualizerView drawDebugInfo):',
-    //     'RMS:', audioData.rms.toFixed(3),
-    //     'Beat:', audioData.beat,
-    //     'Bass:', audioData.bassEnergy.toFixed(3),
-    //     'Mid:', audioData.midEnergy.toFixed(3),
-    //     'Treble:', audioData.trebleEnergy.toFixed(3),
-    //     'BPM:', audioData.bpm,
-    //     'Spectrum Sum:', spectrumSum,
-    //     'First 5 bins:', spectrumSample
-    // );
-
-    ctx.textAlign = 'right';
-    const lineSpacing = 14;
-    let currentY = 20;
-    ctx.fillText(`RMS: ${audioData.rms.toFixed(3)}`, canvas.width - 10, currentY); currentY += lineSpacing;
-    ctx.fillText(`Beat: ${audioData.beat ? 'YES' : 'NO'}`, canvas.width - 10, currentY); currentY += lineSpacing;
-    ctx.fillText(`Bass: ${audioData.bassEnergy.toFixed(3)}`, canvas.width - 10, currentY); currentY += lineSpacing;
-    ctx.fillText(`Mid: ${audioData.midEnergy.toFixed(3)}`, canvas.width - 10, currentY); currentY += lineSpacing;
-    ctx.fillText(`Treble: ${audioData.trebleEnergy.toFixed(3)}`, canvas.width - 10, currentY); currentY += lineSpacing;
-    ctx.fillText(`BPM: ${audioData.bpm}`, canvas.width - 10, currentY);
-  }, [fps, audioData]);
-
-  const drawErrorState = useCallback((ctx: CanvasRenderingContext2D | null) => {
-    if (!ctx) return;
-    const canvas = ctx.canvas;
-    const bgColor = getComputedStyle(canvas).getPropertyValue('--background').trim() || 'black';
-    ctx.fillStyle = bgColor;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    
-    const errorColor = getComputedStyle(canvas).getPropertyValue('--destructive').trim() || 'red';
-    ctx.fillStyle = errorColor;
-    ctx.font = `14px ${SBNF_BODY_FONT_FAMILY}`; // Using SBNF Body Font
-    ctx.textAlign = 'center';
-    
-    const title = 'Visualizer Error:';
-    const errorMessage = lastError || "Unknown error occurred.";
-    const lines = [title];
-    const words = errorMessage.split(' ');
-    let currentLine = "";
-    for (const word of words) {
-        const testLine = currentLine + word + " ";
-        const metrics = ctx.measureText(testLine);
-        const testWidth = metrics.width;
-        if (testWidth > canvas.width * 0.9 && currentLine.length > 0) {
-            lines.push(currentLine.trim());
-            currentLine = word + " ";
-        } else {
-            currentLine = testLine;
-        }
-    }
-    lines.push(currentLine.trim());
-    
-    const lineHeight = 20;
-    const totalHeight = lines.length * lineHeight;
-    let startY = canvas.height / 2 - totalHeight / 2 + lineHeight / 2; // Centered
-    
-    lines.forEach((line) => {
-        ctx.fillText(line, canvas.width / 2, startY);
-        startY += lineHeight;
-    });
-  }, [lastError]);
+  // All 2D drawing functions (get2DContext, drawPrimarySceneContent, drawAiGeneratedOverlay2D, drawDebugInfo, drawErrorState) are removed.
 
   const drawLoop = useCallback(() => {
     animationFrameIdRef.current = requestAnimationFrame(drawLoop);
@@ -323,24 +232,28 @@ export function VisualizerView() {
     updateFps();
 
     const activeSceneDefinition = scenes.find(s => s.id === settings.currentSceneId);
-    const intendedRendererType = activeSceneDefinition?.rendererType || '2d';
+    // intendedRendererType is no longer needed, assume 'webgl' or error/panic.
 
     try {
-      if (settings.panicMode) {
-        if (webGLRendererRef.current && (intendedRendererType === 'webgl' || prevRendererTypeRef.current === 'webgl')) {
+      if (lastError && webGLRendererRef.current) {
+        // If there's a persistent error, clear to black and log it.
+        // This might occur if initWebGL fails repeatedly.
+        console.error("VisualizerView Error in drawLoop (persisting):", lastError);
+        const bgColorString = getComputedStyle(canvas).getPropertyValue('--background').trim() || '#000000';
+        webGLRendererRef.current.setClearColor(new THREE.Color(bgColorString).getHex(), 1);
+        webGLRendererRef.current.clear();
+        // Do not setLastError(null) here, as the error condition might still exist.
+        // The scene init useEffect is responsible for clearing lastError upon successful init.
+      } else if (settings.panicMode) {
+        if (webGLRendererRef.current) {
           webGLRendererRef.current.setClearColor(0x000000, 1);
           webGLRendererRef.current.clear();
-        } else {
-          const ctx = get2DContext();
-          if (ctx) {
-            ctx.fillStyle = 'black';
-            ctx.fillRect(0, 0, canvas.width, canvas.height);
-          }
         }
-        if (lastError) setLastError(null);
-      } else if (intendedRendererType === 'webgl') {
-        if (webGLRendererRef.current && currentSceneWebGLAssetsRef.current && currentSceneWebGLAssetsRef.current.scene && currentSceneWebGLAssetsRef.current.camera && activeSceneDefinition?.drawWebGL) {
-           activeSceneDefinition.drawWebGL({
+        // No need to check lastError here, panic mode overrides.
+        // if (lastError) setLastError(null); // Let init effect handle this if panic mode is exited.
+      } else if (webGLRendererRef.current && currentSceneWebGLAssetsRef.current && currentSceneWebGLAssetsRef.current.scene && currentSceneWebGLAssetsRef.current.camera && activeSceneDefinition?.drawWebGL) {
+        // Normal WebGL rendering path
+        activeSceneDefinition.drawWebGL({
             renderer: webGLRendererRef.current,
             scene: currentSceneWebGLAssetsRef.current.scene,
             camera: currentSceneWebGLAssetsRef.current.camera,
@@ -352,72 +265,115 @@ export function VisualizerView() {
             webcamElement,
           });
           webGLRendererRef.current.render(currentSceneWebGLAssetsRef.current.scene, currentSceneWebGLAssetsRef.current.camera);
+
+          // AI Overlay Rendering for WebGL
+          // Use aiOverlayTexture from state here
+          if (settings.enableAiOverlay && aiOverlayTexture && webGLRendererRef.current && canvasRef.current) {
+            const overlayCanvas = canvasRef.current; 
+            const overlayCamera = new THREE.OrthographicCamera(-overlayCanvas.width / 2, overlayCanvas.width / 2, overlayCanvas.height / 2, -overlayCanvas.height / 2, 0, 1);
+            const overlayScene = new THREE.Scene();
+            const overlayGeometry = new THREE.PlaneGeometry(overlayCanvas.width, overlayCanvas.height);
+            
+            // aiOverlayTexture (from state) is used directly in material.map
+            // The local const aiOverlayTexture is removed.
+            // needsUpdate is handled in useEffect when texture is created/changed.
+
+            const overlayMaterial = new THREE.MeshBasicMaterial();
+            overlayMaterial.map = aiOverlayTexture; // Use texture from state
+            overlayMaterial.transparent = true;
+            overlayMaterial.opacity = settings.aiOverlayOpacity;
+            
+            overlayMaterial.blending = THREE.CustomBlending;
+            switch (settings.aiOverlayBlendMode) {
+              case 'source-over': // Normal
+                overlayMaterial.blendSrc = THREE.SrcAlphaFactor;
+                overlayMaterial.blendDst = THREE.OneMinusSrcAlphaFactor;
+                overlayMaterial.blendEquation = THREE.AddEquation;
+                break;
+              case 'multiply':
+                overlayMaterial.blendSrc = THREE.DstColorFactor;
+                overlayMaterial.blendDst = THREE.ZeroFactor; 
+                overlayMaterial.blendEquation = THREE.AddEquation;
+                break;
+              case 'screen':
+                overlayMaterial.blendSrc = THREE.OneFactor; 
+                overlayMaterial.blendDst = THREE.OneMinusSrcColorFactor;
+                overlayMaterial.blendEquation = THREE.AddEquation;
+                break;
+              case 'add': // Lighter
+                overlayMaterial.blendSrc = THREE.SrcAlphaFactor;
+                overlayMaterial.blendDst = THREE.OneFactor;
+                overlayMaterial.blendEquation = THREE.AddEquation;
+                break;
+              case 'overlay':
+              case 'soft-light':
+              case 'hard-light':
+              case 'difference':
+              case 'exclusion':
+              case 'hue':
+              case 'saturation':
+              case 'color':
+              case 'luminosity':
+              default: // Default to normal blending
+                overlayMaterial.blendSrc = THREE.SrcAlphaFactor;
+                overlayMaterial.blendDst = THREE.OneMinusSrcAlphaFactor;
+                overlayMaterial.blendEquation = THREE.AddEquation;
+                break;
+            }
+
+            const overlayMesh = new THREE.Mesh(overlayGeometry, overlayMaterial);
+            overlayScene.add(overlayMesh);
+
+            // Cache current autoClear states
+            const autoClearCache = webGLRendererRef.current.autoClear;
+            const autoClearColorCache = webGLRendererRef.current.autoClearColor;
+            const autoClearDepthCache = webGLRendererRef.current.autoClearDepth;
+            const autoClearStencilCache = webGLRendererRef.current.autoClearStencil;
+
+            webGLRendererRef.current.autoClear = false; 
+            // No need to set autoClearColor, autoClearDepth, autoClearStencil individually if autoClear is false
+
+            webGLRendererRef.current.render(overlayScene, overlayCamera);
+            
+            // Restore autoClear states
+            webGLRendererRef.current.autoClear = autoClearCache;
+            webGLRendererRef.current.autoClearColor = autoClearColorCache;
+            webGLRendererRef.current.autoClearDepth = autoClearDepthCache;
+            webGLRendererRef.current.autoClearStencil = autoClearStencilCache;
+          }
+
           if (lastError) setLastError(null);
         } else if (webGLRendererRef.current) { 
             // WebGL scene is intended, but resources not fully ready, clear with its own renderer.
              const bgColorString = getComputedStyle(canvas).getPropertyValue('--background').trim() || '#000000';
              webGLRendererRef.current.setClearColor(new THREE.Color(bgColorString).getHex(), 1);
              webGLRendererRef.current.clear();
-             // No 2D context get here
-        } else {
-          // console.log("VisualizerView: WebGL renderer not ready for scene:", activeSceneDefinition?.id);
+        } else if (!webGLRendererRef.current && !lastError) {
+          // Renderer not created, and no specific error reported yet from init.
+          // This might happen if canvas is not ready during first init attempt.
+          // The init useEffect should eventually set an error or create the renderer.
+          console.warn("VisualizerView: WebGL renderer not available in drawLoop, and no specific error set. Canvas might not be ready or init pending.");
         }
-      } else { // 2D Scene
-        const ctx = get2DContext();
-        if (!ctx && activeSceneDefinition && activeSceneDefinition.draw) {
-            if(!lastError) setLastError("VisualizerView: Failed to get 2D context for 2D scene.");
-            return; // Can't draw error if no context
-        }
-
-        if (ctx) { 
-            ctx.clearRect(0, 0, canvas.width, canvas.height); 
-            if (lastError) {
-              drawErrorState(ctx);
-            } else if (activeSceneDefinition && activeSceneDefinition.draw) {
-              if (isTransitioning2D && previousScene2DRef.current && previousScene2DRef.current.draw) {
-                const elapsedTime = performance.now() - transition2DStartTimeRef.current;
-                const progress = Math.min(1, elapsedTime / settings.sceneTransitionDuration);
-                drawPrimarySceneContent(ctx, previousScene2DRef.current, 1 - progress);
-                drawPrimarySceneContent(ctx, activeSceneDefinition, progress);
-                if (progress >= 1) setIsTransitioning2D(false);
-              } else {
-                drawPrimarySceneContent(ctx, activeSceneDefinition);
-              }
-              drawAiGeneratedOverlay2D(ctx);
-              if (!settings.panicMode) drawDebugInfo(ctx);
-            } else {
-              const bgColor = getComputedStyle(canvas).getPropertyValue('--background').trim() || 'black';
-              ctx.fillStyle = bgColor;
-              ctx.fillRect(0, 0, canvas.width, canvas.height);
-              const fgColor = getComputedStyle(canvas).getPropertyValue('--muted-foreground').trim() || 'gray';
-              ctx.fillStyle = fgColor;
-              ctx.textAlign = 'center';
-              ctx.font = `20px ${SBNF_BODY_FONT_FAMILY}`;
-              ctx.fillText(activeSceneDefinition ? 'Scene has no draw function' : 'No scene selected', canvas.width / 2, canvas.height / 2);
-            }
-        }
+        // If lastError is set, the top condition `if (lastError && webGLRendererRef.current)` handles it.
+        // If webGLRendererRef.current is null and lastError IS set, it means renderer creation failed, handled by init.
       }
     } catch (error) {
-      console.error("VisualizerView: Error in draw loop:", error);
+      // This catch block is for errors during the drawWebGL call or overlay rendering itself.
+      console.error("VisualizerView: Runtime error in draw loop (WebGL path):", error);
       const errorMessage = error instanceof Error ? error.message : String(error);
       if (errorMessage !== lastError) setLastError(errorMessage);
-      const ctxForError = get2DContext(); // Attempt to get 2D context to draw error
-      if (ctxForError) drawErrorState(ctxForError);
+      // No 2D error drawing. The `if (lastError)` block at the top will handle clearing.
     }
-    prevRendererTypeRef.current = intendedRendererType;
+    // prevRendererTypeRef.current = intendedRendererType; // This line is removed
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-      settings, audioData, scenes, isTransitioning2D, lastError, fps,
-      get2DContext, drawPrimarySceneContent, drawAiGeneratedOverlay2D, drawDebugInfo, drawErrorState, updateFps,
-      webcamElement
+      settings, audioData, scenes, lastError, fps, 
+      updateFps, 
+      webcamElement,
+      aiOverlayTexture 
+      // Removed get2DContext, drawPrimarySceneContent, drawAiGeneratedOverlay2D, drawDebugInfo, drawErrorState from deps
+      // Removed isTransitioning2D from deps
   ]);
-
-  // Ref to store previous renderer type to manage transitions/cleanup
-  const prevRendererTypeRef = useRef<string>(scenes.find(s => s.id === settings.currentSceneId)?.rendererType || '2d');
-  useEffect(() => {
-    prevRendererTypeRef.current = scenes.find(s => s.id === settings.currentSceneId)?.rendererType || '2d';
-  }, [settings.currentSceneId, scenes]);
-
 
   // Canvas resize effect
   useEffect(() => {
@@ -466,7 +422,7 @@ export function VisualizerView() {
         return () => resizeObserver.disconnect();
       }
     }
-  }, [canvasKey]); // Re-run on canvas re-mount
+  }, []); // Re-run on canvas re-mount (now empty as canvasKey is removed)
 
   useEffect(() => {
     const activeScene = scenes.find(s => s.id === settings.currentSceneId);
@@ -483,7 +439,7 @@ export function VisualizerView() {
 
   return (
     <div className="w-full h-full relative">
-      <canvas ref={canvasRef} className="w-full h-full" key={canvasKey} />
+      <canvas ref={canvasRef} className="w-full h-full" />
       <BrandingOverlay />
       <WebcamFeed onWebcamElement={setWebcamElement} />
     </div>


### PR DESCRIPTION
This commit introduces AI-generated image overlays with blend modes directly into the WebGL rendering pipeline and removes the legacy 2D canvas rendering path.

Key changes:

1.  **WebGL AI Overlay:**
    *   The AI overlay image is now rendered as a textured plane on top of WebGL scenes in `VisualizerView.tsx`.
    *   Opacity (`aiOverlayOpacity`) is applied correctly.
    *   Blend modes (`aiOverlayBlendMode`) are mapped to WebGL blend functions. Supported modes include 'source-over' (normal), 'multiply', 'screen', and 'add'. Other complex modes default to 'source-over'.
    *   Overlay texture management is now handled efficiently using React state and `useEffect`, updating only when the overlay image changes.

2.  **Removal of 2D Canvas Code:**
    *   All 2D canvas rendering logic, including scene drawing, overlay drawing (`drawAiGeneratedOverlay2D`), debug information (`drawDebugInfo`), error states (`drawErrorState`), and 2D-specific transitions, has been removed from `VisualizerView.tsx`.
    *   Associated state, refs, and utility functions (`get2DContext`, etc.) have been deleted.
    *   The `canvasKey` logic for re-mounting the canvas on renderer type change has been removed, as only WebGL is now used.
    *   This significantly simplifies the `VisualizerView` component and focuses it solely on WebGL rendering.

3.  **Documentation Updates:**
    *   The `README.md` has been updated to reflect that:
        *   The visualizer exclusively uses a WebGL rendering pipeline.
        *   AI overlays and blend modes are functional for all WebGL scenes.
        *   The currently supported WebGL blend modes are documented, along with the fallback for more complex modes.

This refactoring makes the AI overlay feature functional with the current WebGL-only scene architecture, improves code maintainability by removing the unused 2D path, and ensures documentation is accurate.