### PR TITLE
Fix: Remove hardcoded secret in debug package

### DIFF
--- a/user-service/node_modules/debug/.coveralls.yml
+++ b/user-service/node_modules/debug/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: SIAeZjKYlHK74rbcFvNHMUzjRiMpflxve


### PR DESCRIPTION
Removes the file user-service/node_modules/debug/.coveralls.yml, which contained a hardcoded repo_token. This file is part of a third-party package and was inadvertently committed.